### PR TITLE
Read query parameters (key, sigAlgo and source) from URL

### DIFF
--- a/components/CreateAccountForm.tsx
+++ b/components/CreateAccountForm.tsx
@@ -16,10 +16,12 @@ export default function CreateAccountForm({
   clientCreateAccount,
   publicKey,
   trafficSource,
+  sigAlgo,
 }: {
   clientCreateAccount: ClientCreateAccount,
   publicKey: string,
   trafficSource: string,
+  sigAlgo: string,
 }) {
   const [errors, setErrors] = useState<string[]>([])
   const [captchaToken, setCaptchaToken] = useState("")
@@ -31,7 +33,7 @@ export default function CreateAccountForm({
       <Formik
         initialValues={{
           publicKey,
-          signatureAlgorithm: "ECDSA_P256",
+          signatureAlgorithm: sigAlgo || "ECDSA_P256",
           hashAlgorithm: "SHA3_256",
         }}
         validationSchema={createAccountSchemaClient}

--- a/components/CreateAccountForm.tsx
+++ b/components/CreateAccountForm.tsx
@@ -14,8 +14,12 @@ import {accountCreated} from "../lib/metrics"
 
 export default function CreateAccountForm({
   clientCreateAccount,
+  publicKey,
+  trafficSource,
 }: {
-  clientCreateAccount: ClientCreateAccount
+  clientCreateAccount: ClientCreateAccount,
+  publicKey: string,
+  trafficSource: string,
 }) {
   const [errors, setErrors] = useState<string[]>([])
   const [captchaToken, setCaptchaToken] = useState("")
@@ -26,7 +30,7 @@ export default function CreateAccountForm({
     <FormContainer>
       <Formik
         initialValues={{
-          publicKey: "",
+          publicKey,
           signatureAlgorithm: "ECDSA_P256",
           hashAlgorithm: "SHA3_256",
         }}
@@ -50,8 +54,7 @@ export default function CreateAccountForm({
           } else if (response.address) {
             const {address} = response
             setAddress(address)
-            mixpanel.track("Faucet: Create Account", {address})
-
+            mixpanel.track("Faucet: Create Account", {address, trafficSource})
             try {
               await accountCreated(mixpanel.get_distinct_id(), address)
             } catch (err) {

--- a/components/CreateAccountPanel.tsx
+++ b/components/CreateAccountPanel.tsx
@@ -3,12 +3,12 @@ import {clientCreateAccount, CreateAccountURLParams} from "lib/client"
 import {Box, Grid} from "theme-ui"
 import CreateAccountForm from "./CreateAccountForm"
 
-export default function CreateAccountPanel({ publicKey, trafficSource} : CreateAccountURLParams) {
+export default function CreateAccountPanel({ publicKey, trafficSource, sigAlgo} : CreateAccountURLParams) {
   return (
     <div>
       <Grid gap={[0, 0, 40, 100]} columns={["auto", "auto", "1.6fr 1fr"]}>
         <Box>
-          <CreateAccountForm publicKey={publicKey} trafficSource={trafficSource} clientCreateAccount={clientCreateAccount} />
+          <CreateAccountForm sigAlgo={sigAlgo} publicKey={publicKey} trafficSource={trafficSource} clientCreateAccount={clientCreateAccount} />
         </Box>
         <Box>
           <Sidebar />

--- a/components/CreateAccountPanel.tsx
+++ b/components/CreateAccountPanel.tsx
@@ -1,14 +1,14 @@
 import Sidebar from "components/Sidebar"
-import {clientCreateAccount} from "lib/client"
+import {clientCreateAccount, CreateAccountURLParams} from "lib/client"
 import {Box, Grid} from "theme-ui"
 import CreateAccountForm from "./CreateAccountForm"
 
-export default function CreateAccountPanel() {
+export default function CreateAccountPanel({ publicKey, trafficSource} : CreateAccountURLParams) {
   return (
     <div>
       <Grid gap={[0, 0, 40, 100]} columns={["auto", "auto", "1.6fr 1fr"]}>
         <Box>
-          <CreateAccountForm clientCreateAccount={clientCreateAccount} />
+          <CreateAccountForm publicKey={publicKey} trafficSource={trafficSource} clientCreateAccount={clientCreateAccount} />
         </Box>
         <Box>
           <Sidebar />

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -3,6 +3,7 @@ import {CREATE_ACCOUNT_ERROR, FUND_ACCOUNT_ERROR} from "lib/constants"
 export type CreateAccountURLParams = {
   publicKey: string
   trafficSource: string
+  sigAlgo: string
 }
 
 export type ClientCreateAccountResult = {

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -1,5 +1,10 @@
 import {CREATE_ACCOUNT_ERROR, FUND_ACCOUNT_ERROR} from "lib/constants"
 
+export type CreateAccountURLParams = {
+  publicKey: string
+  trafficSource: string
+}
+
 export type ClientCreateAccountResult = {
   address: string
   token: string

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -17,5 +17,6 @@ export default function Home(props: CreateAccountURLParams) {
 Home.getInitialProps = async (context: any) => {
   const key: string = context.query.key || ""
   const source: string = context.query.source || ""
-  return { publicKey: key, trafficSource: source }
+  const sigAlgo: string = context.query["sig-algo"] || "ECDSA_P256"
+  return { publicKey: key, sigAlgo, trafficSource: source }
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,13 +2,20 @@ import AppContainer from "components/AppContainer"
 import CreateAccountPanel from "components/CreateAccountPanel"
 import Header from "components/Header"
 import PageTitle from "components/PageTitle"
+import { CreateAccountURLParams } from "lib/client"
 
-export default function Home() {
+export default function Home(props: CreateAccountURLParams) {
   return (
     <AppContainer>
       <PageTitle>Create Account</PageTitle>
       <Header fund={true} />
-      <CreateAccountPanel />
+      <CreateAccountPanel {...props} />
     </AppContainer>
   )
+}
+
+Home.getInitialProps = async (context: any) => {
+  const key: string = context.query.key || ""
+  const source: string = context.query.source || ""
+  return { publicKey: key, trafficSource: source }
 }


### PR DESCRIPTION
Closes #38

## Description

The Create Account flow now automatically prefills `publicKey` and `sigAlgo` with the following query URL parameters:

- `key` : the public key (as per issue #38)
- `sig-algo`: the signature algorithm (as per issue #38), defaulting to `ECDSA_P256`

It also supports an extra `source` parameter, which can be used to identify the traffic source (e.g. kittyitems). This information is included as an additional property in the `"Faucet: Create Account"` mixplanel event.

**DISCLAIMER**: I am not very familiar with the Typescript/React/Next.js stack, so apologies if this is not idiomatic or is not adhering to Next.js best practices. After exploring a couple options, I used getInitialProps to read the query params and provide context to the page as props. I previously tried a simple client-side solution using next/router directly in the form component but it was not prefilling correctly since it was being pre-rendered on the server without re-hydrating. 

**DISCLAIMER #2**: I was not able to get docker running, so I limited my testing to the frontend -- it appears to work fine (parameters can be empty, a nonexistent sigAlgo defaults to ECDSA, etc), but can someone can please E2E test this before merging just in case? (e.g. check creation success, mixpanel events, etc)

---

<!-- Complete: -->

- [x] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
