### PR TITLE
add address as optional query param to faucet

### DIFF
--- a/components/FundAccountForm.tsx
+++ b/components/FundAccountForm.tsx
@@ -13,7 +13,7 @@ import {ClientFundAccountResult} from "./FundAccountPanel"
 import FundAccountSubmitted from "./FundAccountSubmitted"
 import publicConfig from "../lib/publicConfig"
 
-export default function FundAccountForm() {
+export default function FundAccountForm({address}: {address: string}) {
   const [errors, setErrors] = useState<string[]>([])
   const [captchaToken, setCaptchaToken] = useState("")
   const {mixpanel} = useMixpanel()
@@ -25,7 +25,7 @@ export default function FundAccountForm() {
     <FormContainer>
       <Formik
         initialValues={{
-          address: "",
+          address: address,
           token: FLOW_TYPE,
         }}
         validationSchema={fundAccountSchemaClient}

--- a/components/FundAccountForm.tsx
+++ b/components/FundAccountForm.tsx
@@ -28,6 +28,7 @@ export default function FundAccountForm({address}: {address: string}) {
           address: address,
           token: FLOW_TYPE,
         }}
+        enableReinitialize
         validationSchema={fundAccountSchemaClient}
         onSubmit={async ({address, token}, {setSubmitting}) => {
           setErrors([])

--- a/components/FundAccountForm.tsx
+++ b/components/FundAccountForm.tsx
@@ -25,7 +25,7 @@ export default function FundAccountForm({address}: {address: string}) {
     <FormContainer>
       <Formik
         initialValues={{
-          address: "testnet-account-test",
+          address: address,
           token: FLOW_TYPE,
         }}
         validationSchema={fundAccountSchemaClient}

--- a/components/FundAccountForm.tsx
+++ b/components/FundAccountForm.tsx
@@ -25,7 +25,7 @@ export default function FundAccountForm({address}: {address: string}) {
     <FormContainer>
       <Formik
         initialValues={{
-          address: address,
+          address: "testnet-account-test",
           token: FLOW_TYPE,
         }}
         validationSchema={fundAccountSchemaClient}

--- a/components/FundAccountPanel.tsx
+++ b/components/FundAccountPanel.tsx
@@ -8,12 +8,12 @@ export type ClientFundAccountResult = {
   amount: string
 }
 
-export default function FundAccountPanel() {
+export default function FundAccountPanel({address}: {address: string}) {
   return (
     <div>
       <Grid gap={[0, 0, 40, 100]} columns={["auto", "auto", "1.6fr 1fr"]}>
         <Box>
-          <FundAccountForm />
+          <FundAccountForm address={address} />
         </Box>
         <Box>
           <Sidebar />

--- a/pages/fund-account.tsx
+++ b/pages/fund-account.tsx
@@ -6,15 +6,14 @@ import {useRouter} from "next/router"
 
 export default function Fund() {
   const router = useRouter()
-  const {isReady, query} = router
-  const {address} = query
+  const {address} = router.query
   const formattedAddress = Array.isArray(address) ? address[0] : address || ""
 
   return (
     <AppContainer>
       <PageTitle>Fund Account</PageTitle>
       <Header />
-      {isReady && <FundAccountPanel address={formattedAddress} />}
+      <FundAccountPanel address={formattedAddress} />
     </AppContainer>
   )
 }

--- a/pages/fund-account.tsx
+++ b/pages/fund-account.tsx
@@ -2,13 +2,18 @@ import AppContainer from "components/AppContainer"
 import FundAccountPanel from "components/FundAccountPanel"
 import Header from "components/Header"
 import PageTitle from "components/PageTitle"
+import {useRouter} from "next/router"
 
 export default function Fund() {
+  const router = useRouter()
+  const {address} = router.query
+  const formattedAddress = Array.isArray(address) ? address[0] : address || ""
+
   return (
     <AppContainer>
       <PageTitle>Fund Account</PageTitle>
       <Header />
-      <FundAccountPanel />
+      <FundAccountPanel address={formattedAddress} />
     </AppContainer>
   )
 }

--- a/pages/fund-account.tsx
+++ b/pages/fund-account.tsx
@@ -6,14 +6,15 @@ import {useRouter} from "next/router"
 
 export default function Fund() {
   const router = useRouter()
-  const {address} = router.query
+  const {isReady, query} = router
+  const {address} = query
   const formattedAddress = Array.isArray(address) ? address[0] : address || ""
 
   return (
     <AppContainer>
       <PageTitle>Fund Account</PageTitle>
       <Header />
-      <FundAccountPanel address={formattedAddress} />
+      {isReady && <FundAccountPanel address={formattedAddress} />}
     </AppContainer>
   )
 }


### PR DESCRIPTION
Closes #???

## Description

support the `address` query parameter that autofills in the address section of the page. This will be used for the flow-cli funding update for testnet

---

<!-- Complete: -->

- [x] Targeted PR against `main` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
