### PR TITLE
Bump max duration on all endpoints & fix hashing/signing algorithms

### DIFF
--- a/lib/crypto.ts
+++ b/lib/crypto.ts
@@ -1,9 +1,3 @@
-import {
-  ECDSA_P256,
-  ECDSA_secp256k1,
-  SHA2_256,
-  SHA3_256,
-} from "@onflow/util-encode-key"
 import {createHash} from "crypto"
 import {ec as EC} from "elliptic"
 import {SHA3} from "sha3"
@@ -12,13 +6,13 @@ export type SigAlgoTypes = "ECDSA_P256" | "ECDSA_secp256k1"
 export type HashAlgoTypes = "SHA2_256" | "SHA3_256"
 
 export const SigAlgos: Record<SigAlgoTypes, number> = {
-  ECDSA_P256: ECDSA_P256,
-  ECDSA_secp256k1: ECDSA_secp256k1,
+  ECDSA_P256: 1,
+  ECDSA_secp256k1: 2,
 }
 
 export const HashAlgos: Record<HashAlgoTypes, number> = {
-  SHA2_256: SHA2_256,
-  SHA3_256: SHA3_256,
+  SHA2_256: 1,
+  SHA3_256: 3,
 }
 
 const hashSHA2 = (msg: string) => {

--- a/modules.d.ts
+++ b/modules.d.ts
@@ -102,5 +102,4 @@ declare module "*.cdc" {
   export default content
 }
 
-declare module "@onflow/util-encode-key"
 declare module "@onflow/types"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
         "@hcaptcha/react-hcaptcha": "^0.3.4",
         "@onflow/fcl": "1.9.0",
         "@onflow/types": "1.2.1",
-        "@onflow/util-encode-key": "1.2.1",
         "@prisma/client": "^4.2.1",
         "@theme-ui/match-media": "^0.9.1",
         "clipboard-copy": "^4.0.1",
@@ -1599,16 +1598,6 @@
       "integrity": "sha512-+pf8AlOsJoGsW5cJYFhJE0IOQZY6GvsvULK1MXMcIF6/4ROjjKUDkZM+1frMjxf2j9hY58UEgciEIVdzS+bIZA==",
       "dependencies": {
         "@babel/runtime": "^7.18.6"
-      }
-    },
-    "node_modules/@onflow/util-encode-key": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@onflow/util-encode-key/-/util-encode-key-1.2.1.tgz",
-      "integrity": "sha512-Blqpi0Xox4sHjxM+Qcu1RP8Li5DbTMSMxnK8+VPjHibbeQXlg+bva7mskgtMcJyjZfemqhRuubjNwTMbwGiOrw==",
-      "dependencies": {
-        "@babel/runtime": "^7.18.6",
-        "@onflow/rlp": "^1.2.1",
-        "@onflow/util-invariant": "^1.2.1"
       }
     },
     "node_modules/@onflow/util-invariant": {
@@ -9241,16 +9230,6 @@
       "integrity": "sha512-+pf8AlOsJoGsW5cJYFhJE0IOQZY6GvsvULK1MXMcIF6/4ROjjKUDkZM+1frMjxf2j9hY58UEgciEIVdzS+bIZA==",
       "requires": {
         "@babel/runtime": "^7.18.6"
-      }
-    },
-    "@onflow/util-encode-key": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@onflow/util-encode-key/-/util-encode-key-1.2.1.tgz",
-      "integrity": "sha512-Blqpi0Xox4sHjxM+Qcu1RP8Li5DbTMSMxnK8+VPjHibbeQXlg+bva7mskgtMcJyjZfemqhRuubjNwTMbwGiOrw==",
-      "requires": {
-        "@babel/runtime": "^7.18.6",
-        "@onflow/rlp": "^1.2.1",
-        "@onflow/util-invariant": "^1.2.1"
       }
     },
     "@onflow/util-invariant": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "@hcaptcha/react-hcaptcha": "^0.3.4",
     "@onflow/fcl": "1.9.0",
     "@onflow/types": "1.2.1",
-    "@onflow/util-encode-key": "1.2.1",
     "@prisma/client": "^4.2.1",
     "@theme-ui/match-media": "^0.9.1",
     "clipboard-copy": "^4.0.1",

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
     "functions": {
-        "pages/api/fund.ts": {
+        "pages/api/**/*.ts": {
             "maxDuration": 60
         }
     }


### PR DESCRIPTION
## Description

This PR does 2 things:

1. Bumps `maxDuration` to 60s on all API endpoints (only `fund.ts` was bumped previously, this handles account creation as well)
2. Fixes hashing/signing algorithms incorrectly numbered.  This is an issue in @onflow/util-encode-key (see https://github.com/onflow/fcl-js/issues/1851) which must be seperately investigated considering upcoming changes to the Cadence 1.0 key management API.