### PR TITLE
Improve conversion of EVM addresses

### DIFF
--- a/cadence/scripts/evm/get_balance.cdc
+++ b/cadence/scripts/evm/get_balance.cdc
@@ -3,12 +3,6 @@ import "EVM"
 /// Returns the Flow balance of of a given EVM address in FlowEVM
 ///
 access(all) fun main(address: String): UFix64 {
-    let bytes = address.decodeHex()
-    let addressBytes: [UInt8; 20] = [
-        bytes[0], bytes[1], bytes[2], bytes[3], bytes[4],
-        bytes[5], bytes[6], bytes[7], bytes[8], bytes[9],
-        bytes[10], bytes[11], bytes[12], bytes[13], bytes[14],
-        bytes[15], bytes[16], bytes[17], bytes[18], bytes[19]
-    ]
-    return EVM.EVMAddress(bytes: addressBytes).balance().inFLOW()
+    let bytes = address.decodeHex().toConstantSized<[UInt8; 20]>()!
+    return EVM.EVMAddress(bytes: bytes).balance().inFLOW()
 }

--- a/components/FundAccountSubmitted.tsx
+++ b/components/FundAccountSubmitted.tsx
@@ -71,14 +71,8 @@ export default function FundAccountSubmitted({
       /// Returns the Flow balance of a given EVM address in FlowEVM
       ///
       access(all) fun main(address: String): UFix64 {
-        let bytes = address.decodeHex()
-        let addressBytes: [UInt8; 20] = [
-          bytes[0], bytes[1], bytes[2], bytes[3], bytes[4],
-          bytes[5], bytes[6], bytes[7], bytes[8], bytes[9],
-          bytes[10], bytes[11], bytes[12], bytes[13], bytes[14],
-          bytes[15], bytes[16], bytes[17], bytes[18], bytes[19]
-        ]
-        return EVM.EVMAddress(bytes: addressBytes).balance().inFLOW()
+        let bytes = address.decodeHex().toConstantSized<[UInt8; 20]>()!
+        return EVM.EVMAddress(bytes: bytes).balance().inFLOW()
       }`
             : `import FungibleToken from ${publicConfig.contractFungibleToken}
 import FlowToken from ${publicConfig.contractFlowToken}


### PR DESCRIPTION
## Description

Use `toConstantSized` function to convert `[UInt8]` to `[UInt8;20]` needed for `EVM.EVMAddress`

---

<!-- Complete: -->

- [x] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
